### PR TITLE
Better path input handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,13 +92,13 @@ async function main() {
 
     if (answers.source == 'local') {
       let local = await inquirer.prompt([getLocalApk]);
-      pathToApk = await utility.verifyPathToApk(local.pathToApk);
+      pathToApk = await utility.verifyPathToApk(local.pathToApk.trim());
       console.log('\n');
     }
 
     else if (answers.source == 'remote') {
       let remote = await inquirer.prompt([getRemoteApk]);
-      urlToApk = await utility.verifyUrlToApk(remote.urlToApk);
+      urlToApk = await utility.verifyUrlToApk(remote.urlToApk.trim());
       pathToApk = await utility.downloadApk(root, urlToApk);
     }
   }

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -81,17 +81,18 @@ module.exports = {
    * @returns {path} pathToApk
    */
   verifyPathToApk: async function (pathToApk) {
-    pathToApk = path.resolve(pathToApk);
-    while (!fs.existsSync(pathToApk)) {
+    let resolvedPath = path.resolve(pathToApk);
+    while (!pathToApk || !fs.existsSync(resolvedPath)) {
       console.log(
         chalk.red('Path to APK is invalid. Please verify correct path and try again.'),
-        chalk.red('Current path: ', pathToApk)
+        chalk.red('Current path: ', resolvedPath)
       );
       let correctPath = await inquirer.prompt([correctLocalApk]);
       pathToApk = correctPath.pathToApk;
+      resolvedPath = path.resolve(pathToApk);
     }
     console.log('\n');
-    return pathToApk;
+    return resolvedPath;
   },
 
   /**
@@ -106,7 +107,7 @@ module.exports = {
         chalk.red('Current URL: ', urlToApk)
       );
       let correctUrl = await inquirer.prompt([correctRemoteApk]);
-      urlToApk = correctUrl.urlToApk
+      urlToApk = correctUrl.urlToApk;
     }
     console.log('\n');
     return urlToApk;

--- a/lib/utility.js
+++ b/lib/utility.js
@@ -88,7 +88,7 @@ module.exports = {
         chalk.red('Current path: ', resolvedPath)
       );
       let correctPath = await inquirer.prompt([correctLocalApk]);
-      pathToApk = correctPath.pathToApk;
+      pathToApk = correctPath.pathToApk.trim();
       resolvedPath = path.resolve(pathToApk);
     }
     console.log('\n');
@@ -107,7 +107,7 @@ module.exports = {
         chalk.red('Current URL: ', urlToApk)
       );
       let correctUrl = await inquirer.prompt([correctRemoteApk]);
-      urlToApk = correctUrl.urlToApk;
+      urlToApk = correctUrl.urlToApk.trim();
     }
     console.log('\n');
     return urlToApk;


### PR DESCRIPTION
Entering an empty path or one with whitespace before/after would cause inspector to error out. This PR trims whitespace & ensures resulting entered path isn't empty.